### PR TITLE
extend before hook timeout

### DIFF
--- a/server/src/test/integration/drinksEndpointTest.js
+++ b/server/src/test/integration/drinksEndpointTest.js
@@ -9,6 +9,9 @@ describe(`'drinks' route - api test`, function() {
   let token;
 
   before(async function() {
+    // increase hook timeout, tests require extensive environment setup
+    this.timeout(3000);
+
     // prime the database with test tables/data
     const tables = await dbAdapter.r.tableList();
     const drinkTestObjects = [

--- a/server/src/test/integration/usersEndpointTest.js
+++ b/server/src/test/integration/usersEndpointTest.js
@@ -9,6 +9,9 @@ describe(`'users' route - api test`, function() {
   let token;
 
   before(async function() {
+    // increase hook timeout, tests require extensive environment setup
+    this.timeout(3000);
+
     // prime the database with test tables/data
     const tables = await dbAdapter.r.tableList();
     if (tables.includes('users')) {


### PR DESCRIPTION
To try and resolve #74, I extended the timeout of the `before all` hook in the integration tests. Hopefully 3000 ms will be enough (50% increase) but if not, I'll increase it again.

Remember back when I didn't use arrow functions in tests _just in case_ I had to use mocha's context? I guess that worked out!