### PR TITLE
add catch-all route handler

### DIFF
--- a/server/src/server.js
+++ b/server/src/server.js
@@ -5,7 +5,7 @@ const cors = require('cors');
 const api = require('./api');
 const logger = require('./utils/logger');
 const checkJwt = require('./utils/auth');
-const constants = require('./utils/stringConstants');
+const strings = require('./utils/stringConstants').errors;
 
 const app = express();
 
@@ -25,12 +25,24 @@ app.use(checkJwt);
 // set up the api as middleware
 app.use('/api/v1', api);
 
+// handle all incorrect routes under `/api`
+app.all('*', (req, res, next) => {
+  const err = new Error();
+  err.name = 'RouteNotFoundError';
+  next(err);
+});
+
 // global error handling middleware
 app.use((err, req, res, next) => {
   switch (err.name) {
+    case 'RouteNotFoundError':
+      logger.error(strings.NONEXISTENT);
+      res.status(404).json(strings.NONEXISTENT);
+      break;
+
     case 'UnauthorizedError':
-      logger.error(constants.errors.UNAUTHORIZED);
-      res.status(401).json(constants.errors.UNAUTHORIZED);
+      logger.error(strings.UNAUTHORIZED);
+      res.status(401).json(strings.UNAUTHORIZED);
       break;
 
     default:

--- a/server/src/test/integration/badEndpointTest.js
+++ b/server/src/test/integration/badEndpointTest.js
@@ -25,7 +25,7 @@ describe(`'bad' routes - api test`, function() {
         expect(res.body).to.equal(strings.errors.NONEXISTENT);
         done();
       });
-  })
+  });
 
   it('GET - return a 404 if api route does not exist', function(done) {
     request(app)
@@ -36,5 +36,5 @@ describe(`'bad' routes - api test`, function() {
         expect(res.body).to.equal(strings.errors.NONEXISTENT);
         done();
       });
-  })
-})
+  });
+});

--- a/server/src/test/integration/badEndpointTest.js
+++ b/server/src/test/integration/badEndpointTest.js
@@ -1,0 +1,40 @@
+const app = require('../../server');
+const request = require('supertest');
+const expect = require('chai').expect;
+const axios = require('axios');
+const testObjects = require('../../utils/testObjects');
+const strings = require('../../utils/stringConstants');
+
+// this test suite is for routes unhandled by the API routers
+describe(`'bad' routes - api test`, function() {
+  let token;
+
+  before(async function() {
+    this.timeout(9000);
+    const response = await axios(testObjects.tokenRequestOptions);
+    token = response.data.access_token;
+    return;
+  });
+
+  it('GET - return a 404 if top level route does not exist', function(done) {
+    request(app)
+      .get('/hamburgular')
+      .set('Authorization', 'Bearer ' + token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(404);
+        expect(res.body).to.equal(strings.errors.NONEXISTENT);
+        done();
+      });
+  })
+
+  it('GET - return a 404 if api route does not exist', function(done) {
+    request(app)
+      .post('/api/v1/hamburgular')
+      .set('Authorization', 'Bearer ' + token)
+      .end((err, res) => {
+        expect(res.statusCode).to.equal(404);
+        expect(res.body).to.equal(strings.errors.NONEXISTENT);
+        done();
+      });
+  })
+})

--- a/server/src/utils/stringConstants.js
+++ b/server/src/utils/stringConstants.js
@@ -1,6 +1,7 @@
 module.exports = {
   errors: {
-    UNAUTHORIZED: 'Request is not authorized.'
+    UNAUTHORIZED: 'Request is not authorized.',
+    NONEXISTENT: 'This route does not exist.'
   },
   test: {
     ID: 'email|7984284578419749'


### PR DESCRIPTION
Add a route that should catch any request the API routers don't catch. Format an error in there and pass it along to be caught by the error handling middleware.