### PR TITLE
add global setup and teardown functions for mocha

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -3699,6 +3699,12 @@
         }
       }
     },
+    "mocha-prepare": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mocha-prepare/-/mocha-prepare-0.1.0.tgz",
+      "integrity": "sha1-VRMidoEiLkNJSB7k5GJHLzHGu4I=",
+      "dev": true
+    },
     "moment": {
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "start": "nodemon src/index.js",
     "database": "rethinkdb",
-    "test": "NODE_ENV=test nyc --all mocha src/test/unit/**/*.js",
-    "test-all": "NODE_ENV=test nyc --all mocha src/test/**/*.js",
+    "test": "NODE_ENV=test nyc --all mocha test/unit/**/*.js",
+    "test-all": "NODE_ENV=test nyc --all mocha test/**/*.js",
     "coverage": "nyc report --reporter=text-lcov > coverage.lcov && codecov",
-    "lint": "eslint src",
-    "fix": "eslint --fix src"
+    "lint": "eslint src test",
+    "fix": "eslint --fix src test"
   },
   "repository": {
     "type": "git",
@@ -47,6 +47,7 @@
     "eslint-config-prettier": "^2.7.0",
     "eslint-plugin-prettier": "^2.3.1",
     "mocha": "^4.0.1",
+    "mocha-prepare": "^0.1.0",
     "nodemon": "^1.12.1",
     "nyc": "^11.3.0",
     "prettier": "^1.7.4",
@@ -58,9 +59,7 @@
       "**/src/**/*.js"
     ],
     "exclude": [
-      "**/src/utils/seed.js",
-      "**/src/utils/mockObjects.js",
-      "**/src/test/**"
+      "**/src/utils/seed.js"
     ]
   }
 }

--- a/server/test/integration/badEndpointTest.js
+++ b/server/test/integration/badEndpointTest.js
@@ -1,18 +1,14 @@
-const app = require('../../server');
+const app = require('../../src/server');
 const request = require('supertest');
 const expect = require('chai').expect;
-const axios = require('axios');
-const testObjects = require('../../utils/testObjects');
-const strings = require('../../utils/stringConstants');
+const strings = require('../../src/utils/stringConstants');
 
 // this test suite is for routes unhandled by the API routers
 describe(`'bad' routes - api test`, function() {
-  let token;
+  const token = global.testToken;
 
   before(async function() {
     this.timeout(9000);
-    const response = await axios(testObjects.tokenRequestOptions);
-    token = response.data.access_token;
     return;
   });
 

--- a/server/test/integration/badEndpointTest.js
+++ b/server/test/integration/badEndpointTest.js
@@ -7,11 +7,6 @@ const strings = require('../../src/utils/stringConstants');
 describe(`'bad' routes - api test`, function() {
   const token = global.testToken;
 
-  before(async function() {
-    this.timeout(9000);
-    return;
-  });
-
   it('GET - return a 404 if top level route does not exist', function(done) {
     request(app)
       .get('/hamburgular')

--- a/server/test/integration/drinksEndpointTest.js
+++ b/server/test/integration/drinksEndpointTest.js
@@ -1,13 +1,12 @@
-const app = require('../../server');
+const app = require('../../src/server');
 const request = require('supertest');
 const expect = require('chai').expect;
-const dbAdapter = require('../../db/adapter');
-const axios = require('axios');
-const testObjects = require('../../utils/testObjects');
-const strings = require('../../utils/stringConstants');
+const dbAdapter = require('../../src/db/adapter');
+const testObjects = require('../utils/testObjects');
+const strings = require('../../src/utils/stringConstants');
 
 describe(`'drinks' route - api test`, function() {
-  let token;
+  const token = global.testToken;
 
   before(async function() {
     // increase hook timeout, tests require extensive environment setup
@@ -21,10 +20,6 @@ describe(`'drinks' route - api test`, function() {
     }
     await dbAdapter.r.tableCreate('drinks', { primaryKey: 'name' });
     await dbAdapter.r.table('drinks').insert(testObjects.drinkTest);
-
-    const response = await axios(testObjects.tokenRequestOptions);
-    token = response.data.access_token;
-
     return;
   });
 

--- a/server/test/integration/drinksEndpointTest.js
+++ b/server/test/integration/drinksEndpointTest.js
@@ -9,9 +9,6 @@ describe(`'drinks' route - api test`, function() {
   const token = global.testToken;
 
   before(async function() {
-    // increase hook timeout, tests require extensive environment setup
-    this.timeout(9000);
-
     // prime the database with test tables/data
     const tables = await dbAdapter.r.tableList();
 

--- a/server/test/integration/usersEndpointTest.js
+++ b/server/test/integration/usersEndpointTest.js
@@ -8,9 +8,6 @@ describe(`'users' route - api test`, function() {
   const token = global.testToken;
 
   before(async function() {
-    // increase hook timeout, tests require extensive environment setup
-    this.timeout(9000);
-
     // prime the database with test tables/data
     const tables = await dbAdapter.r.tableList();
     if (tables.includes('users')) {

--- a/server/test/integration/usersEndpointTest.js
+++ b/server/test/integration/usersEndpointTest.js
@@ -1,13 +1,11 @@
-const app = require('../../server');
+const app = require('../../src/server');
 const request = require('supertest');
 const expect = require('chai').expect;
-const dbAdapter = require('../../db/adapter');
-const axios = require('axios');
-const options = require('../../utils/testObjects').tokenRequestOptions;
-const strings = require('../../utils/stringConstants');
+const dbAdapter = require('../../src/db/adapter');
+const strings = require('../../src/utils/stringConstants');
 
 describe(`'users' route - api test`, function() {
-  let token;
+  const token = global.testToken;
 
   before(async function() {
     // increase hook timeout, tests require extensive environment setup
@@ -19,18 +17,6 @@ describe(`'users' route - api test`, function() {
       await dbAdapter.r.tableDrop('users');
     }
     await dbAdapter.r.tableCreate('users');
-
-    // get a temporary bearer token for testing
-    const response = await axios(options);
-    token = response.data.access_token;
-
-    return;
-  });
-
-  // after the tests, drain the connection pool so the process exits properly
-  // this has to happen after the last tests are run
-  after(async function() {
-    await dbAdapter.r.getPoolMaster().drain();
     return;
   });
 

--- a/server/test/mocha.opts
+++ b/server/test/mocha.opts
@@ -1,0 +1,1 @@
+--require test/prepare

--- a/server/test/prepare.js
+++ b/server/test/prepare.js
@@ -7,7 +7,7 @@ const dbAdapter = require('../src/db/adapter');
   First function passed into `prepare` is the global `before`
   - It requests a test token from auth0 to use for the tests
 
-  Second function passed into `prepare` is the global `before`
+  Second function passed into `prepare` is the global `after`
   - It drains the connection pool so the process exits correctly
 
 */

--- a/server/test/prepare.js
+++ b/server/test/prepare.js
@@ -1,0 +1,24 @@
+const prepare = require('mocha-prepare');
+const getToken = require('./utils/getTestToken');
+const dbAdapter = require('../src/db/adapter');
+
+/*
+
+  First function passed into `prepare` is the global `before`
+  - It requests a test token from auth0 to use for the tests
+
+  Second function passed into `prepare` is the global `before`
+  - It drains the connection pool so the process exits correctly
+
+*/
+
+prepare(
+  async function(done) {
+    global.testToken = await getToken();
+    done();
+  },
+  async function(done) {
+    await dbAdapter.r.getPoolMaster().drain();
+    done();
+  }
+);

--- a/server/test/unit/drinkControllerTest.js
+++ b/server/test/unit/drinkControllerTest.js
@@ -1,5 +1,5 @@
 const expect = require('chai').expect;
-const controllerModule = require('../../api/drink/drinkController');
+const controllerModule = require('../../src/api/drink/drinkController');
 const sinon = require('sinon');
 
 describe('drinks controller - unit test', function(done) {

--- a/server/test/unit/userControllerTest.js
+++ b/server/test/unit/userControllerTest.js
@@ -1,8 +1,8 @@
 const expect = require('chai').expect;
-const controllerModule = require('../../api/user/userController');
+const controllerModule = require('../../src/api/user/userController');
 const sinon = require('sinon');
-const res = require('../../utils/testObjects').res;
-const strings = require('../../utils/stringConstants').test;
+const res = require('../utils/testObjects').res;
+const strings = require('../../src/utils/stringConstants').test;
 
 describe('users controller - unit test', function(done) {
   it('.create - set correct status code and user object', async function() {

--- a/server/test/utils/getTestToken.js
+++ b/server/test/utils/getTestToken.js
@@ -1,0 +1,16 @@
+const axios = require('axios');
+const auth = require('../../config').auth;
+
+module.exports = async function getTestToken() {
+  const options = {
+    method: 'POST',
+    url: 'https://bartop.auth0.com/oauth/token',
+    headers: { 'content-type': 'application/json' },
+    data: `{"client_id":"${auth.id}",
+            "client_secret":"${auth.secret}",
+            "audience":"${auth.audience}",
+            "grant_type":"${auth.grant}"}`
+  };
+  const response = await axios(options);
+  return response.data.access_token;
+};

--- a/server/test/utils/testObjects.js
+++ b/server/test/utils/testObjects.js
@@ -1,17 +1,3 @@
-const auth = require('../../config').auth;
-
-// axios request options for hitting the auth0 API
-// to get a test access token
-const options = {
-  method: 'POST',
-  url: 'https://bartop.auth0.com/oauth/token',
-  headers: { 'content-type': 'application/json' },
-  data: `{"client_id":"${auth.id}",
-          "client_secret":"${auth.secret}",
-          "audience":"${auth.audience}",
-          "grant_type":"${auth.grant}"}`
-};
-
 // test object to place in the database for testing
 // the GET drinks endpoint
 const drinkTestObjects = [
@@ -40,5 +26,4 @@ const Response = class {
 };
 
 module.exports.res = new Response();
-module.exports.tokenRequestOptions = options;
 module.exports.drinkTest = drinkTestObjects;


### PR DESCRIPTION
1. Moved the `test/` folder out of `src/` and into the root folder, because that's how mocha prefers it and it made everything way easier. Not to mention, I think it makes a lot of sense that the test code be separated from the project source code. Not sure why I didn't do it like that in the first place.

2. Moved the test code that was in `src/utils/` to `test/utils/` for better separation of code that is in the project and code used for testing.

3. Added a `mocha.opts` file. This is essentially for specifying more command line args but is easier to set up and makes `package.json` cleaner. The only line in here is specifying to load `test/prepare.js` before anything else.

4. Added a `prepare.js` file that uses `mocha-prepare` to call one function before all of the tests and one function after all of the tests. Using the setup function to get a test token from Auth0 and using the tear-down function to drain the DB connection pool. Before I was having to manually determine which test was the last one and drain it after that.