### PR TITLE
fix config to match env variable

### DIFF
--- a/server/config.js
+++ b/server/config.js
@@ -12,7 +12,9 @@ if (!envFileIsValid()) {
 }
 
 let dbName;
-environment === 'test' ? (dbName = 'test') : (dbName = process.env.DB_NAME);
+environment === 'test'
+  ? (dbName = 'test')
+  : (dbName = process.env.BARTOP_DB_NAME);
 
 module.exports = {
   database: {


### PR DESCRIPTION
I was right, `dev` and `test` environments were using the same database. All because when I changed the `.env` names in that one PR, I forgot to switch just one of them in `config.js`. So, `dbName` was `undefined` every time the tests or the API ran.

Man, that was a sneaky bug and went unnoticed for a while. That is one of the pros of statically typed languages I guess. Also, I'm _very_ surprised this didn't cause the program to crash when it tried to connect to a DB with no name. I'm thinking that Rethink defaults to the `test` database when there is no name provided. I'm glad I caught this now rather than later! Sneaky, sneaky, sneaky.