### PR TITLE
add descriptions for graphql schema

### DIFF
--- a/bartop-api/src/api/drink/drink.graphql.js
+++ b/bartop-api/src/api/drink/drink.graphql.js
@@ -1,24 +1,44 @@
 module.exports = `
-# primary type
+# Data model representing a cocktail in BarTop
 type Drink {
-  id: String
+
+  # Database-generated key to identify the Drink
+  id: ID
+
+  # Name of the cocktail
   name: String
+
+  # Brief summary describing the cocktail
   description: String
+
+  # List of instructions describing how to make the cocktail
   instructions: [String]
+
+  # List of ingredients used to make the cocktail
   ingredients: [Ingredient]
 }
 
-# sub-types for drink type
+# Describes an ingredient to be used in a cocktail
 type Ingredient {
+
+  # The specific ingredient to use (whiskey, simple syrup, etc)
   ingredient: String
+
+  # Amount object describing how much of the ingredient to use
   amount: Amount
 }
 
+# Describes the amount of an ingredient to use
 type Amount {
-  quantity: Int
+
+  # Numeric quantity of the amount to use
+  quantity: Float
+
+  # Unit that describes the numeric quantity value (oz, dashes, etc)
   unit: String
 }
 
 extend type Query {
+  # Returns a list of all drinks
   listDrinks: [Drink]
 }`;

--- a/bartop-api/src/api/user/user.graphql.js
+++ b/bartop-api/src/api/user/user.graphql.js
@@ -1,17 +1,29 @@
 module.exports = `
+# Data model representing a user in BarTop
 type User {
-  id: String,
+
+  # Database-generated key to identify the User
+  id: ID,
+
+  # User ID provided by and used to interact with Auth0
   auth0Id: String
 }
 
+# Input type containing data needed to create a new User
 input UserInput {
+
+  # # User ID provided by and used to interact with Auth0
   auth0Id: String
 }
 
+# The root Query for BarTop's GraphQL interface
 type Query {
+  # Returns a list of all users
   listUsers: [User]
 }
 
+# The root Mutation for BarTop's GraphQL interface
 type Mutation {
+  # Creates a new user
   createUser(newUser: UserInput!): User!
 }`;


### PR DESCRIPTION
This is hype. Just go through the GraphIQL with these descriptions; it feels cool.

Descriptions are added to the schema by simply adding comments above whatever you want to describe, as you will see.

I also changed the ids to type `ID` and the `quantity` field to type `Float`.

Definitely let me know if you think any of these descriptions could be more helpful or if there's anything you would add. You are the end-user after all.