### PR TITLE
Refactor bad user test - graphql

### DIFF
--- a/bartop-api/src/api/user/user.graphql.js
+++ b/bartop-api/src/api/user/user.graphql.js
@@ -16,7 +16,7 @@ type User {
 input UserInput {
 
   # User ID provided by and used to interact with Auth0
-  auth0Id: String
+  auth0Id: String!
 }
 
 # The root Query for BarTop's GraphQL interface

--- a/bartop-api/test/integration/usersEndpointTest.js
+++ b/bartop-api/test/integration/usersEndpointTest.js
@@ -126,7 +126,7 @@ describe('Resource - User', function() {
     it('Mutation - error on creating user with bad schema', function(done) {
       const query = `
         mutation {
-          createUser(newUser: { id: "${users.testUser.auth0Id}" }) {
+          createUser(newUser: {}) {
             id
           }
         }`;
@@ -139,7 +139,7 @@ describe('Resource - User', function() {
           const error = res.body.errors[0];
           expect(res.statusCode).to.equal(400);
           expect(error.message).to.equal(
-            'Field "id" is not defined by type UserInput.'
+            'Field UserInput.auth0Id of required type String! was not provided.'
           );
           done();
         });


### PR DESCRIPTION
To be reviewed after #147 

Changing the bad user test to be used as a regression test for the user schema. This was great because I caught a bug - I was not previously requiring `auth0Id` to be passed in to create a new user, it was optional! Not anymore \*phew\*