### PR TITLE
Use Graphql best practices

### DIFF
--- a/bartop-api/src/api/catalog/catalog.controller.js
+++ b/bartop-api/src/api/catalog/catalog.controller.js
@@ -4,8 +4,8 @@ const model = require('./catalog.model');
 const asyncMiddleware = require('../../utils/asyncMiddleware');
 const validateInput = require('../../utils/validators');
 
-module.exports.create = asyncMiddleware(async (req, res, next) => {
+module.exports.replace = asyncMiddleware(async (req, res, next) => {
   validateInput.onPost(req, model);
-  const result = await logic.create(req.body);
+  const result = await logic.replace(req.body);
   res.status(201).json(result);
 });

--- a/bartop-api/src/api/catalog/catalog.graphql.js
+++ b/bartop-api/src/api/catalog/catalog.graphql.js
@@ -1,11 +1,11 @@
 module.exports = `
 # Input type containing data needed to create a catalog for a user
-input CatalogInput {
+input CreateCatalogInput {
   userId: ID!
   drinkIds: [ID]!
 }
 
 extend type Mutation {
   # Creates a new catalog for a user
-  createCatalog(newCatalog: CatalogInput!): User!
+  createCatalog(input: CreateCatalogInput!): User!
 }`;

--- a/bartop-api/src/api/catalog/catalog.graphql.js
+++ b/bartop-api/src/api/catalog/catalog.graphql.js
@@ -1,11 +1,26 @@
 module.exports = `
 # Input type containing data needed to create a catalog for a user
-input CreateCatalogInput {
+input ReplaceCatalogInput {
+
+  # The catalog will be replaced for the User with this unique ID
   userId: ID!
+
+  # List of IDs that correspond to Drink objects in the DB
   drinkIds: [ID]!
 }
 
+# Return type of replaceCatalog
+type ReplaceCatalogPayload {
+
+  # The new Catalog object for the User
+  catalog: [ID] # this should perhaps resolve the drinks
+
+  # A flag that will be 'true' if the given Catalog is identical to the existing Catalog, and 'null' otherwise.
+  unchanged: Boolean
+}
+
 extend type Mutation {
-  # Creates a new catalog for a user
-  createCatalog(input: CreateCatalogInput!): User!
+
+  # Completely replaces an existing catalog with a new one. Should be used to initialize catalogs (by replacing empty ones).
+  replaceCatalog(input: ReplaceCatalogInput!): ReplaceCatalogPayload!
 }`;

--- a/bartop-api/src/api/catalog/catalog.logic.js
+++ b/bartop-api/src/api/catalog/catalog.logic.js
@@ -2,18 +2,22 @@ const processDbResult = require('../../utils/processDbResult');
 
 module.exports = r => {
   // create a new catalog
-  const create = async body => {
+  const replace = async body => {
     const { userId, drinkIds } = body;
     const dbOpResult = await r
       .table('users')
       .get(userId)
       .update({ catalog: drinkIds }, { returnChanges: true });
 
-    return processDbResult(dbOpResult, userId, {
-      id: userId,
-      catalog: drinkIds
-    });
+    let finalResult = processDbResult(dbOpResult, userId);
+    if (finalResult.unchanged) {
+      finalResult = { catalog: drinkIds, unchanged: true };
+    } else {
+      finalResult = { catalog: finalResult.catalog };
+    }
+
+    return finalResult;
   };
 
-  return { create };
+  return { replace };
 };

--- a/bartop-api/src/api/catalog/catalog.resolvers.js
+++ b/bartop-api/src/api/catalog/catalog.resolvers.js
@@ -1,8 +1,8 @@
 const db = require('../../db');
 const logic = require('./catalog.logic')(db);
 
-const createCatalog = async (root, { newCatalog }) => {
-  return await logic.create(newCatalog);
+const createCatalog = async (root, { input }) => {
+  return await logic.create(input);
 };
 
 module.exports = {

--- a/bartop-api/src/api/catalog/catalog.resolvers.js
+++ b/bartop-api/src/api/catalog/catalog.resolvers.js
@@ -1,12 +1,12 @@
 const db = require('../../db');
 const logic = require('./catalog.logic')(db);
 
-const createCatalog = async (root, { input }) => {
-  return await logic.create(input);
+const replaceCatalog = async (root, { input }) => {
+  return await logic.replace(input);
 };
 
 module.exports = {
   Mutation: {
-    createCatalog
+    replaceCatalog
   }
 };

--- a/bartop-api/src/api/catalog/catalog.restRouter.js
+++ b/bartop-api/src/api/catalog/catalog.restRouter.js
@@ -1,7 +1,7 @@
 const router = require('express').Router();
 const controller = require('./catalog.controller');
 
-// post catalogs/
-router.route('/').post(controller.create);
+// put catalogs/
+router.route('/').put(controller.replace);
 
 module.exports = router;

--- a/bartop-api/src/api/user/user.graphql.js
+++ b/bartop-api/src/api/user/user.graphql.js
@@ -13,7 +13,7 @@ type User {
 }
 
 # Input type containing data needed to create a new User
-input UserInput {
+input CreateUserInput {
 
   # User ID provided by and used to interact with Auth0
   auth0Id: String!
@@ -28,5 +28,5 @@ type Query {
 # The root Mutation for BarTop's GraphQL interface
 type Mutation {
   # Creates a new user
-  createUser(newUser: UserInput!): User!
+  createUser(input: CreateUserInput!): User!
 }`;

--- a/bartop-api/src/api/user/user.graphql.js
+++ b/bartop-api/src/api/user/user.graphql.js
@@ -12,6 +12,13 @@ type User {
   catalog: [ID] # todo: change to [Drink] and write a resolver to handle it
 }
 
+# Return type of createUser
+type CreateUserPayload {
+
+  # The created User object
+  user: User
+}
+
 # Input type containing data needed to create a new User
 input CreateUserInput {
 
@@ -28,5 +35,5 @@ type Query {
 # The root Mutation for BarTop's GraphQL interface
 type Mutation {
   # Creates a new user
-  createUser(input: CreateUserInput!): User!
+  createUser(input: CreateUserInput!): CreateUserPayload!
 }`;

--- a/bartop-api/src/api/user/user.resolvers.js
+++ b/bartop-api/src/api/user/user.resolvers.js
@@ -6,7 +6,8 @@ const listUsers = async () => {
 };
 
 const createUser = async (root, { input }) => {
-  return await logic.create(input);
+  const newUser = await logic.create(input);
+  return { user: newUser };
 };
 
 module.exports = {

--- a/bartop-api/src/api/user/user.resolvers.js
+++ b/bartop-api/src/api/user/user.resolvers.js
@@ -5,8 +5,8 @@ const listUsers = async () => {
   return await logic.list();
 };
 
-const createUser = async (root, { newUser }) => {
-  return await logic.create(newUser);
+const createUser = async (root, { input }) => {
+  return await logic.create(input);
 };
 
 module.exports = {

--- a/bartop-api/src/utils/processDbResult.js
+++ b/bartop-api/src/utils/processDbResult.js
@@ -1,13 +1,11 @@
-const merge = require('lodash.merge');
-
-module.exports = (dbOpResult, id = '', body = {}) => {
+module.exports = (dbOpResult, id = '') => {
   let result = {};
   if (!dbOpResult.changes.length) {
     if (dbOpResult.unchanged) {
-      // the catalog was already the exact same
-      result = merge(body, { metadata: { unchanged: true } });
+      // the resource was already the exact same
+      result = { unchanged: true };
     } else if (dbOpResult.skipped) {
-      // the userid doesn't exist in the db
+      // the id doesn't exist in the db
       const newError = new Error();
       newError.name = 'ResourceNotFoundError';
       newError.message = `Resource with ID:${id} does not exist.`;

--- a/bartop-api/test/integration/catalogsEndpointTest.js
+++ b/bartop-api/test/integration/catalogsEndpointTest.js
@@ -27,42 +27,39 @@ describe('Resource - Catalog', function() {
   describe('Rest', function() {
     const drinkIds = ['drink1', 'drink2'];
 
-    it('POST - create a new catalog for a user', function(done) {
+    it('PUT - replace a catalog for a user', function(done) {
       request(app)
-        .post('/api/v1/catalogs')
+        .put('/api/v1/catalogs')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${TOKEN}`)
         .send({ userId, drinkIds })
         .end((err, res) => {
           expect(res.statusCode).to.equal(201);
           expect(res.body).to.be.an('object');
-          expect(res.body.id).to.equal(userId);
-          expect(res.body.auth0Id).to.equal(users.testUser.auth0Id);
           expect(res.body.catalog).to.deep.equal(drinkIds);
           done();
         });
     });
 
-    it('POST - send metadata for unchanged catalog', function(done) {
+    it('PUT - send metadata for unchanged catalog', function(done) {
       request(app)
-        .post('/api/v1/catalogs')
+        .put('/api/v1/catalogs')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${TOKEN}`)
         .send({ userId, drinkIds })
         .end((err, res) => {
           expect(res.statusCode).to.equal(201);
           expect(res.body).to.be.an('object');
-          expect(res.body.id).to.equal(userId);
           expect(res.body.catalog).to.deep.equal(drinkIds);
-          expect(res.body.metadata.unchanged).to.equal(true);
+          expect(res.body.unchanged).to.equal(true);
           done();
         });
     });
 
-    it('POST - throw error if user does not exist', function(done) {
+    it('PUT - throw error if user does not exist', function(done) {
       const thisError = errors.NOT_FOUND;
       request(app)
-        .post('/api/v1/catalogs')
+        .put('/api/v1/catalogs')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${TOKEN}`)
         .send({ userId: 'Arnald', drinkIds })
@@ -73,10 +70,10 @@ describe('Resource - Catalog', function() {
         });
     });
 
-    it('POST - throw error if body does not match model', function(done) {
+    it('PUT - throw error if body does not match model', function(done) {
       const thisError = errors.BODY_MODEL;
       request(app)
-        .post('/api/v1/catalogs')
+        .put('/api/v1/catalogs')
         .set('Content-Type', 'application/json')
         .set('Authorization', `Bearer ${TOKEN}`)
         .send({ id: users.postUser.auth0Id })
@@ -87,10 +84,10 @@ describe('Resource - Catalog', function() {
         });
     });
 
-    it('POST - throw error if content-type is unsupported', function(done) {
+    it('PUT - throw error if content-type is unsupported', function(done) {
       const thisError = errors.CONTENT_TYPE;
       request(app)
-        .post('/api/v1/catalogs')
+        .put('/api/v1/catalogs')
         .set('Content-Type', 'multipart/form-data')
         .set('Authorization', `Bearer ${TOKEN}`)
         // if content-type is not set to json,
@@ -107,15 +104,14 @@ describe('Resource - Catalog', function() {
   describe('GraphQL', function() {
     const drinkIds = ['drink3', 'drink4'];
 
-    it('Mutation - create a new catalog for a user', function(done) {
+    it('Mutation - replace empty catalog for a user', function(done) {
       const query = `
         mutation {
-          createCatalog(input: { userId: "${userId}", drinkIds: ["${drinkIds.join(
+          replaceCatalog(input: { userId: "${userId}", drinkIds: ["${drinkIds.join(
         '", "'
       )}"] }) {
-            id
-            auth0Id
             catalog
+            unchanged
           }
         }`;
       request(app)
@@ -124,22 +120,47 @@ describe('Resource - Catalog', function() {
         .set('Content-Type', 'application/json')
         .send({ query })
         .end((err, res) => {
-          // createCatalog returns the updated user object
-          const user = res.body.data.createCatalog;
+          // replaceCatalog returns the updated catalog array
+          const payload = res.body.data.replaceCatalog;
           expect(res.statusCode).to.equal(200);
-          expect(user).to.be.an('object');
-          expect(user.id).to.be.a('string');
-          expect(user.auth0Id).to.equal(users.testUser.auth0Id);
-          expect(user.catalog).to.deep.equal(drinkIds);
+          expect(payload).to.be.an('object');
+          expect(payload.catalog).to.deep.equal(drinkIds);
+          expect(payload.unchanged).to.equal(null);
           done();
         });
     });
 
-    it('Mutation - error on creating user with bad schema', function(done) {
+    it('Mutation - return unchanged when replacing catalog with identical catalog', function(done) {
       const query = `
         mutation {
-          createCatalog(input: {}) {
-            id
+          replaceCatalog(input: { userId: "${userId}", drinkIds: ["${drinkIds.join(
+        '", "'
+      )}"] }) {
+            catalog
+            unchanged
+          }
+        }`;
+      request(app)
+        .post('/api/graphql')
+        .set('Authorization', `Bearer ${TOKEN}`)
+        .set('Content-Type', 'application/json')
+        .send({ query })
+        .end((err, res) => {
+          // replaceCatalog returns the updated catalog array
+          const payload = res.body.data.replaceCatalog;
+          expect(res.statusCode).to.equal(200);
+          expect(payload).to.be.an('object');
+          expect(payload.catalog).to.deep.equal(drinkIds);
+          expect(payload.unchanged).to.equal(true);
+          done();
+        });
+    });
+
+    it('Mutation - error on replacing a catalog with bad schema', function(done) {
+      const query = `
+        mutation {
+          replaceCatalog(input: {}) {
+            catalog
           }
         }`;
       request(app)
@@ -152,10 +173,10 @@ describe('Resource - Catalog', function() {
           expect(res.statusCode).to.equal(400);
           expect(errorResponse.length).to.equal(2);
           expect(errorResponse[0].message).to.equal(
-            'Field CreateCatalogInput.userId of required type ID! was not provided.'
+            'Field ReplaceCatalogInput.userId of required type ID! was not provided.'
           );
           expect(errorResponse[1].message).to.equal(
-            'Field CreateCatalogInput.drinkIds of required type [ID]! was not provided.'
+            'Field ReplaceCatalogInput.drinkIds of required type [ID]! was not provided.'
           );
           done();
         });

--- a/bartop-api/test/integration/catalogsEndpointTest.js
+++ b/bartop-api/test/integration/catalogsEndpointTest.js
@@ -110,7 +110,7 @@ describe('Resource - Catalog', function() {
     it('Mutation - create a new catalog for a user', function(done) {
       const query = `
         mutation {
-          createCatalog(newCatalog: { userId: "${userId}", drinkIds: ["${drinkIds.join(
+          createCatalog(input: { userId: "${userId}", drinkIds: ["${drinkIds.join(
         '", "'
       )}"] }) {
             id
@@ -138,7 +138,7 @@ describe('Resource - Catalog', function() {
     it('Mutation - error on creating user with bad schema', function(done) {
       const query = `
         mutation {
-          createCatalog(newCatalog: {}) {
+          createCatalog(input: {}) {
             id
           }
         }`;
@@ -152,10 +152,10 @@ describe('Resource - Catalog', function() {
           expect(res.statusCode).to.equal(400);
           expect(errorResponse.length).to.equal(2);
           expect(errorResponse[0].message).to.equal(
-            'Field CatalogInput.userId of required type ID! was not provided.'
+            'Field CreateCatalogInput.userId of required type ID! was not provided.'
           );
           expect(errorResponse[1].message).to.equal(
-            'Field CatalogInput.drinkIds of required type [ID]! was not provided.'
+            'Field CreateCatalogInput.drinkIds of required type [ID]! was not provided.'
           );
           done();
         });

--- a/bartop-api/test/integration/usersEndpointTest.js
+++ b/bartop-api/test/integration/usersEndpointTest.js
@@ -104,8 +104,10 @@ describe('Resource - User', function() {
       const query = `
         mutation {
           createUser(input: { auth0Id: "${users.testUser.auth0Id}" }) {
-            id
-            auth0Id
+            user {
+              id
+              auth0Id
+            }
           }
         }`;
       request(app)
@@ -114,7 +116,7 @@ describe('Resource - User', function() {
         .set('Content-Type', 'application/json')
         .send({ query })
         .end((err, res) => {
-          const user = res.body.data.createUser;
+          const user = res.body.data.createUser.user;
           expect(res.statusCode).to.equal(200);
           expect(user).to.be.an('object');
           expect(user.id).to.not.equal(users.testUser.auth0Id);
@@ -127,7 +129,9 @@ describe('Resource - User', function() {
       const query = `
         mutation {
           createUser(input: {}) {
-            id
+            user {
+              id
+            }
           }
         }`;
       request(app)

--- a/bartop-api/test/integration/usersEndpointTest.js
+++ b/bartop-api/test/integration/usersEndpointTest.js
@@ -103,7 +103,7 @@ describe('Resource - User', function() {
     it('Mutation - create a new user', function(done) {
       const query = `
         mutation {
-          createUser(newUser: { auth0Id: "${users.testUser.auth0Id}" }) {
+          createUser(input: { auth0Id: "${users.testUser.auth0Id}" }) {
             id
             auth0Id
           }
@@ -126,7 +126,7 @@ describe('Resource - User', function() {
     it('Mutation - error on creating user with bad schema', function(done) {
       const query = `
         mutation {
-          createUser(newUser: {}) {
+          createUser(input: {}) {
             id
           }
         }`;
@@ -139,7 +139,7 @@ describe('Resource - User', function() {
           const error = res.body.errors[0];
           expect(res.statusCode).to.equal(400);
           expect(error.message).to.equal(
-            'Field UserInput.auth0Id of required type String! was not provided.'
+            'Field CreateUserInput.auth0Id of required type String! was not provided.'
           );
           done();
         });

--- a/bartop-api/test/unit/processDbResult.js
+++ b/bartop-api/test/unit/processDbResult.js
@@ -14,7 +14,7 @@ describe('Util - Process DB Result', function() {
     };
     const result = processDbResult(dbOpResult);
     expect(result).to.be.an('object');
-    expect(result.metadata.unchanged).to.equal(true);
+    expect(result.unchanged).to.equal(true);
     done();
   });
 

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -93,24 +93,32 @@ paths:
           $ref: '#/components/responses/GeneralError'
 
   /catalogs:
-    post:
-      summary: Create a new catalog for a user.
-      description: Creates a new catalog for a user, consisting of entirely the passed-in drink IDs.
-      operationId: createCatalog
+    put:
+      summary: Replace an existing or empty catalog for a user.
+      description: Fully replaces the catalog for a user with the passed-in drink IDs. Can be used to initialize a user's catalog.
+      operationId: replaceCatalog
       requestBody:
         required: true
         description: JSON object containing the new Catalog to be created.
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Catalog'
+              type: object
+              properties:
+                catalog:
+                  $ref: '#/components/schemas/DrinksArray'
+                unchanged:
+                  type: Boolean
+                  description: true if the catalog was not changed. Null, undefined, or false if catalog was replaced.
+
+              $ref: '#/components/schemas/DrinksArray'
       responses:
         '201':
           description: New Catalog successfully created.
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/User'
+                $ref: '#/components/schemas/Catalog'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '404':


### PR DESCRIPTION
Based on that one article, we learned two things:
1. It is good to use specific input types for mutations and identify them with only the word `input`
2. It is good to use specific payload types for each mutation

I updated the API to utilize both of these best practices. In addition, I changed the catalog creation route to be a "replace" or `PUT` because that's what it really is and can be used as such. I also changed the replace catalog operation to return the new catalog rather than the whole user. Seems more fitting since we're treating `catalog` as its own resource.

Lemme know what you think about all this.