### PR TITLE
stop reporting patch coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: 85%
         threshold: 5%
+    patch: no
   notify:
     slack:
       default:


### PR DESCRIPTION
Dug around the documentation a bit, realized `patch` is set to `yes` be default and has to be overwritten to be turned off. This should stop patch coverage reporting.

Output of the `codecov` YAML validation tool:
```
Valid!

{
  "coverage": {
    "notify": {
      "slack": {
        "default": {
          "only_pulls": false,
          "url": "<secret>",
          "flags": null,
          "branches": null,
          "threshold": 0.0,
          "paths": null
        }
      }
    },
    "status": {
      "project": {
        "default": {
          "target": 85.0,
          "threshold": 5.0
        }
      },
      "patch": false
    }
  }
}
```