### PR TITLE
dependency updates

### DIFF
--- a/bartop-api/package-lock.json
+++ b/bartop-api/package-lock.json
@@ -168,11 +168,6 @@
         "@types/express": "4.0.39"
       }
     },
-    "@types/graphql": {
-      "version": "0.12.6",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/@types/graphql/-/graphql-0.12.6.tgz",
-      "integrity": "sha1-PWGRmFhfyr5fThrftc9fM4jGbBM="
-    },
     "@types/mime": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.0.tgz",
@@ -303,13 +298,20 @@
       }
     },
     "apollo-link": {
-      "version": "1.2.2",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/apollo-link/-/apollo-link-1.2.2.tgz",
-      "integrity": "sha1-VMhBmbGKwa+NY1U6aMo4nAUhegM=",
+      "version": "1.2.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/apollo-link/-/apollo-link-1.2.1.tgz",
+      "integrity": "sha1-wSCxYFn5vZNAG59yuU0vgPPzBdI=",
       "requires": {
-        "@types/graphql": "0.12.6",
+        "@types/node": "9.6.7",
         "apollo-utilities": "1.0.11",
         "zen-observable-ts": "0.8.9"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "9.6.7",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/@types/node/-/node-9.6.7.tgz",
+          "integrity": "sha1-XzgW0dshVe3N4bLjql0OXFIMtWQ="
+        }
       }
     },
     "apollo-utilities": {
@@ -707,8 +709,8 @@
     },
     "browser-stdout": {
       "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/browser-stdout/-/browser-stdout-1.3.1.tgz",
+      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
       "dev": true
     },
     "buffer-equal-constant-time": {
@@ -917,184 +919,14 @@
       "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "codecov": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.0.tgz",
-      "integrity": "sha1-wnO4xPEpRXI+jcnSWAPYk0Pl8o4=",
+      "version": "3.0.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/codecov/-/codecov-3.0.1.tgz",
+      "integrity": "sha1-zExc0ZVca+R/bdovjFW8xDxzLco=",
       "dev": true,
       "requires": {
         "argv": "0.0.2",
-        "request": "2.81.0",
+        "request": "2.83.0",
         "urlgrey": "0.4.4"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "4.11.8",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
-          "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
-        },
-        "assert-plus": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
-          "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ=",
-          "dev": true
-        },
-        "aws-sign2": {
-          "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
-          "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8=",
-          "dev": true
-        },
-        "boom": {
-          "version": "2.10.1",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
-          "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        },
-        "cryptiles": {
-          "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
-          "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
-        },
-        "form-data": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.4.tgz",
-          "integrity": "sha1-M8GDrPGTJ27KqYFDpp6Uv+4XUNE=",
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.18"
-          },
-          "dependencies": {
-            "mime-types": {
-              "version": "2.1.18",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
-              "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
-              "dev": true,
-              "requires": {
-                "mime-db": "1.33.0"
-              }
-            }
-          }
-        },
-        "har-schema": {
-          "version": "1.0.5",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
-          "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4=",
-          "dev": true
-        },
-        "har-validator": {
-          "version": "4.2.1",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
-          "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
-          "dev": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
-        },
-        "hawk": {
-          "version": "3.1.3",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-          "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
-        },
-        "http-signature": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-          "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
-          "dev": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.13.1"
-          }
-        },
-        "mime-types": {
-          "version": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-          "integrity": "sha512-rOFZoFAbaupSpzARUe5CU1P9mwfX+lIFAuj0soNsEZEnrHu6LZNyV7/FClEB/oF9A1o5KStlumRjW6D4Q2FRCA==",
-          "dev": true,
-          "requires": {
-            "mime-db": "1.30.0"
-          },
-          "dependencies": {
-            "mime-db": {
-              "version": "1.30.0",
-              "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-              "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
-              "dev": true
-            }
-          }
-        },
-        "performance-now": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
-          "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU=",
-          "dev": true
-        },
-        "qs": {
-          "version": "6.4.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-          "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM=",
-          "dev": true
-        },
-        "request": {
-          "version": "2.81.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
-          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.1.0"
-          }
-        },
-        "sntp": {
-          "version": "1.0.9",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
-          "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
-        }
       }
     },
     "collection-visit": {
@@ -1137,8 +969,8 @@
     },
     "commander": {
       "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/commander/-/commander-2.11.0.tgz",
+      "integrity": "sha1-FXFS/R56bI2YpbcVzzdt+SgARWM=",
       "dev": true
     },
     "component-emitter": {
@@ -1335,7 +1167,7 @@
       "dependencies": {
         "ms": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         }
       }
@@ -1435,7 +1267,7 @@
     },
     "deprecated-decorator": {
       "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
       "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "destroy": {
@@ -1445,8 +1277,8 @@
     },
     "diff": {
       "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-      "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/diff/-/diff-3.5.0.tgz",
+      "integrity": "sha1-gAwN0eCov7yVg1wgKtIg/jF+WhI=",
       "dev": true
     },
     "dns-prefetch-control": {
@@ -3195,11 +3027,11 @@
       }
     },
     "graphql-tools": {
-      "version": "2.24.0",
-      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/graphql-tools/-/graphql-tools-2.24.0.tgz",
-      "integrity": "sha1-u6yq0DkkASoO24c1peZd9dVWNnU=",
+      "version": "3.0.0",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/graphql-tools/-/graphql-tools-3.0.0.tgz",
+      "integrity": "sha1-/yKtFTFfwmjehjnQOTa5EdeLnps=",
       "requires": {
-        "apollo-link": "1.2.2",
+        "apollo-link": "1.2.1",
         "apollo-utilities": "1.0.11",
         "deprecated-decorator": "0.1.6",
         "iterall": "1.2.2",
@@ -3208,8 +3040,8 @@
     },
     "growl": {
       "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/growl/-/growl-1.10.3.tgz",
+      "integrity": "sha1-GSa6kM8+3+KttJJ/WIC8IsZseQ8=",
       "dev": true
     },
     "har-schema": {
@@ -3346,12 +3178,6 @@
       "resolved": "https://registry.npmjs.org/hide-powered-by/-/hide-powered-by-1.0.0.tgz",
       "integrity": "sha1-SoWtZYgfYoV/xwr3F0oRhNzM4ys="
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
     "hpkp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hpkp/-/hpkp-2.0.0.tgz",
@@ -3438,7 +3264,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
       "dev": true
     },
     "ini": {
@@ -3798,15 +3624,6 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
       "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
-    "json-stable-stringify": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
-      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
-      "dev": true,
-      "requires": {
-        "jsonify": "0.0.0"
-      }
-    },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
@@ -3817,12 +3634,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
       "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsonify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
-      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
-      "dev": true
     },
     "jsonwebtoken": {
       "version": "8.2.0",
@@ -4171,9 +3982,9 @@
       }
     },
     "mocha": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.0.tgz",
-      "integrity": "sha512-d6RWgYPILd+AoWVOxiD0UwUqRicnE1inTxMr40CXOgqYve1MvnKntoLAtLIcxjEeVjEoYYTe5QAq3mUc6/ySjQ==",
+      "version": "5.1.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/mocha/-/mocha-5.1.1.tgz",
+      "integrity": "sha1-t3THVgnawF60j02bodgnuX/eins=",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
@@ -4191,8 +4002,8 @@
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
           "dev": true,
           "requires": {
             "ms": "2.0.0"
@@ -4407,9 +4218,9 @@
       }
     },
     "nyc": {
-      "version": "11.6.0",
-      "resolved": "https://registry.npmjs.org/nyc/-/nyc-11.6.0.tgz",
-      "integrity": "sha512-ZaXCh0wmbk2aSBH2B5hZGGvK2s9aM8DIm2rVY+BG3Fx8tUS+bpJSswUVZqOD1YfCmnYRFSqgYJSr7UeeUcW0jg==",
+      "version": "11.7.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/nyc/-/nyc-11.7.1.tgz",
+      "integrity": "sha1-fLCkIuUBuI/ywWNDQd7CVgKZ1ns=",
       "dev": true,
       "requires": {
         "archy": "1.0.0",
@@ -4427,7 +4238,7 @@
         "istanbul-lib-instrument": "1.10.1",
         "istanbul-lib-report": "1.1.3",
         "istanbul-lib-source-maps": "1.2.3",
-        "istanbul-reports": "1.3.0",
+        "istanbul-reports": "1.4.0",
         "md5-hex": "1.3.0",
         "merge-source-map": "1.1.0",
         "micromatch": "2.3.11",
@@ -4518,7 +4329,7 @@
           "dev": true
         },
         "atob": {
-          "version": "2.0.3",
+          "version": "2.1.0",
           "bundled": true,
           "dev": true
         },
@@ -4560,7 +4371,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "core-js": "2.5.3",
+            "core-js": "2.5.5",
             "regenerator-runtime": "0.11.1"
           }
         },
@@ -4588,7 +4399,7 @@
             "babylon": "6.18.0",
             "debug": "2.6.9",
             "globals": "9.18.0",
-            "invariant": "2.2.3",
+            "invariant": "2.2.4",
             "lodash": "4.17.5"
           }
         },
@@ -4635,8 +4446,39 @@
                 "is-descriptor": "1.0.2"
               }
             },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -4746,59 +4588,8 @@
                 "is-descriptor": "0.1.6"
               }
             },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
             "isobject": {
               "version": "3.0.1",
-              "bundled": true,
-              "dev": true
-            },
-            "kind-of": {
-              "version": "5.1.0",
               "bundled": true,
               "dev": true
             }
@@ -4863,7 +4654,7 @@
           "dev": true
         },
         "core-js": {
-          "version": "2.5.3",
+          "version": "2.5.5",
           "bundled": true,
           "dev": true
         },
@@ -4916,8 +4707,39 @@
             "isobject": "3.0.1"
           },
           "dependencies": {
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -5256,7 +5078,7 @@
           "dev": true
         },
         "invariant": {
-          "version": "2.2.3",
+          "version": "2.2.4",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5269,18 +5091,11 @@
           "dev": true
         },
         "is-accessor-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
+            "kind-of": "3.2.2"
           }
         },
         "is-arrayish": {
@@ -5302,32 +5117,25 @@
           }
         },
         "is-data-descriptor": {
-          "version": "1.0.0",
+          "version": "0.1.4",
           "bundled": true,
           "dev": true,
           "requires": {
-            "kind-of": "6.0.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "6.0.2",
-              "bundled": true,
-              "dev": true
-            }
+            "kind-of": "3.2.2"
           }
         },
         "is-descriptor": {
-          "version": "1.0.2",
+          "version": "0.1.6",
           "bundled": true,
           "dev": true,
           "requires": {
-            "is-accessor-descriptor": "1.0.0",
-            "is-data-descriptor": "1.0.0",
-            "kind-of": "6.0.2"
+            "is-accessor-descriptor": "0.1.6",
+            "is-data-descriptor": "0.1.4",
+            "kind-of": "5.1.0"
           },
           "dependencies": {
             "kind-of": {
-              "version": "6.0.2",
+              "version": "5.1.0",
               "bundled": true,
               "dev": true
             }
@@ -5529,7 +5337,7 @@
           }
         },
         "istanbul-reports": {
-          "version": "1.3.0",
+          "version": "1.4.0",
           "bundled": true,
           "dev": true,
           "requires": {
@@ -5831,39 +5639,6 @@
               "dev": true,
               "requires": {
                 "is-descriptor": "0.1.6"
-              }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "5.1.0",
-                  "bundled": true,
-                  "dev": true
-                }
               }
             }
           }
@@ -6320,57 +6095,6 @@
               "requires": {
                 "is-extendable": "0.1.1"
               }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -6392,8 +6116,39 @@
                 "is-descriptor": "1.0.2"
               }
             },
+            "is-accessor-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-data-descriptor": {
+              "version": "1.0.0",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
+              }
+            },
             "isobject": {
               "version": "3.0.1",
+              "bundled": true,
+              "dev": true
+            },
+            "kind-of": {
+              "version": "6.0.2",
               "bundled": true,
               "dev": true
             }
@@ -6417,7 +6172,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "atob": "2.0.3",
+            "atob": "2.1.0",
             "decode-uri-component": "0.2.0",
             "resolve-url": "0.2.1",
             "source-map-url": "0.4.0",
@@ -6494,57 +6249,6 @@
               "requires": {
                 "is-descriptor": "0.1.6"
               }
-            },
-            "is-accessor-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-data-descriptor": {
-              "version": "0.1.4",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
-              }
-            },
-            "is-descriptor": {
-              "version": "0.1.6",
-              "bundled": true,
-              "dev": true,
-              "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
-              }
-            },
-            "kind-of": {
-              "version": "5.1.0",
-              "bundled": true,
-              "dev": true
             }
           }
         },
@@ -6604,7 +6308,7 @@
           "dev": true,
           "requires": {
             "arrify": "1.0.1",
-            "micromatch": "3.1.9",
+            "micromatch": "3.1.10",
             "object-assign": "4.1.1",
             "read-pkg-up": "1.0.1",
             "require-main-filename": "1.0.1"
@@ -6621,17 +6325,15 @@
               "dev": true
             },
             "braces": {
-              "version": "2.3.1",
+              "version": "2.3.2",
               "bundled": true,
               "dev": true,
               "requires": {
                 "arr-flatten": "1.1.0",
                 "array-unique": "0.3.2",
-                "define-property": "1.0.0",
                 "extend-shallow": "2.0.1",
                 "fill-range": "4.0.0",
                 "isobject": "3.0.1",
-                "kind-of": "6.0.2",
                 "repeat-element": "1.1.2",
                 "snapdragon": "0.8.2",
                 "snapdragon-node": "2.1.1",
@@ -6639,14 +6341,6 @@
                 "to-regex": "3.0.2"
               },
               "dependencies": {
-                "define-property": {
-                  "version": "1.0.0",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-descriptor": "1.0.2"
-                  }
-                },
                 "extend-shallow": {
                   "version": "2.0.1",
                   "bundled": true,
@@ -6685,6 +6379,42 @@
                   "dev": true,
                   "requires": {
                     "is-extendable": "0.1.1"
+                  }
+                },
+                "is-accessor-descriptor": {
+                  "version": "0.1.6",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
+                  }
+                },
+                "is-data-descriptor": {
+                  "version": "0.1.4",
+                  "bundled": true,
+                  "dev": true,
+                  "requires": {
+                    "kind-of": "3.2.2"
+                  },
+                  "dependencies": {
+                    "kind-of": {
+                      "version": "3.2.2",
+                      "bundled": true,
+                      "dev": true,
+                      "requires": {
+                        "is-buffer": "1.1.6"
+                      }
+                    }
                   }
                 },
                 "is-descriptor": {
@@ -6759,39 +6489,29 @@
               }
             },
             "is-accessor-descriptor": {
-              "version": "0.1.6",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
+                "kind-of": "6.0.2"
               }
             },
             "is-data-descriptor": {
-              "version": "0.1.4",
+              "version": "1.0.0",
               "bundled": true,
               "dev": true,
               "requires": {
-                "kind-of": "3.2.2"
-              },
-              "dependencies": {
-                "kind-of": {
-                  "version": "3.2.2",
-                  "bundled": true,
-                  "dev": true,
-                  "requires": {
-                    "is-buffer": "1.1.6"
-                  }
-                }
+                "kind-of": "6.0.2"
+              }
+            },
+            "is-descriptor": {
+              "version": "1.0.2",
+              "bundled": true,
+              "dev": true,
+              "requires": {
+                "is-accessor-descriptor": "1.0.0",
+                "is-data-descriptor": "1.0.0",
+                "kind-of": "6.0.2"
               }
             },
             "is-number": {
@@ -6823,13 +6543,13 @@
               "dev": true
             },
             "micromatch": {
-              "version": "3.1.9",
+              "version": "3.1.10",
               "bundled": true,
               "dev": true,
               "requires": {
                 "arr-diff": "4.0.0",
                 "array-unique": "0.3.2",
-                "braces": "2.3.1",
+                "braces": "2.3.2",
                 "define-property": "2.0.2",
                 "extend-shallow": "3.0.2",
                 "extglob": "2.0.4",
@@ -7416,9 +7136,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.12.0.tgz",
-      "integrity": "sha512-Wz0SMncgaglBzDcohH3ZIAi4nVpzOIEweFzCOmgVEoRSeO72b4dcKGfgxoRGVMaFlh1r7dlVaJ+f3CIHfeH6xg==",
+      "version": "1.12.1",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/prettier/-/prettier-1.12.1.tgz",
+      "integrity": "sha1-wa0g6APndJ+vkFpAnSNn4Gu+cyU=",
       "dev": true
     },
     "process-nextick-args": {
@@ -8195,8 +7915,8 @@
     },
     "supports-color": {
       "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/supports-color/-/supports-color-4.4.0.tgz",
+      "integrity": "sha1-iD992rwWUUKyphQn8zUt7RldGj4=",
       "dev": true,
       "requires": {
         "has-flag": "2.0.0"
@@ -8641,9 +8361,9 @@
       }
     },
     "winston": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
+      "version": "2.4.2",
+      "resolved": "https://na.artifactory.swg-devops.com:443/artifactory/api/npm/cxl-sdk-gen-npm-virtual/winston/-/winston-2.4.2.tgz",
+      "integrity": "sha1-PKAfdjEW/EjbYQU7dUTnUEMfjbA=",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/bartop-api/package.json
+++ b/bartop-api/package.json
@@ -36,27 +36,27 @@
     "express-graphql": "^0.6.12",
     "express-jwt": "^5.3.1",
     "graphql": "^0.13.2",
-    "graphql-tools": "^2.24.0",
+    "graphql-tools": "^3.0.0",
     "helmet": "^3.12.0",
     "jwks-rsa": "^1.2.1",
     "lodash.merge": "^4.6.1",
     "morgan": "^1.9.0",
     "rethinkdbdash": "^2.3.31",
-    "winston": "^2.4.1"
+    "winston": "^2.4.2"
   },
   "devDependencies": {
     "axios": "^0.18.0",
     "babel-eslint": "^8.2.3",
     "chai": "^4.1.2",
-    "codecov": "^3.0.0",
+    "codecov": "^3.0.1",
     "eslint": "^4.19.1",
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-prettier": "^2.6.0",
-    "mocha": "^5.1.0",
+    "mocha": "^5.1.1",
     "mocha-prepare": "^0.1.0",
     "nodemon": "^1.17.3",
-    "nyc": "^11.6.0",
-    "prettier": "^1.12.0",
+    "nyc": "^11.7.1",
+    "prettier": "^1.12.1",
     "supertest": "^3.0.0"
   },
   "nyc": {


### PR DESCRIPTION
Update Friday:

Made some patch, minor, _and_ a major update today. The major version update is for `graphql-tools`. I'm only using this package for a limited purpose and am not using any of the APIs that had breaking changes.

[Changelog for update](https://github.com/apollographql/graphql-tools/blob/master/CHANGELOG.md#v300)

Relevant section of BT code:
```js
const { makeExecutableSchema } = require('graphql-tools');

//                ***                 ***

const schema = makeExecutableSchema({
  typeDefs: [baseSchema, drinkSchema, userSchema, catalogSchema],
  resolvers: merge({}, drinkResolvers, userResolvers, catalogResolvers)
});
```